### PR TITLE
Feature/44/adopt to new get sli events

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -6,21 +6,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: 1.13
         id: go
-      - name: Add $GOPATH/bin
-        run: |
-          echo ::add-path::$(go env GOPATH)/bin
       - name: Check out code.
         uses: actions/checkout@v1
       - name: Install linters
         run: '( mkdir linters && cd linters && go get golang.org/x/lint/golint )'
-      - name: Setup reviewdog
-        run: |
-          mkdir -p $HOME/bin && curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b $HOME/bin
-          echo ::add-path::$HOME/bin
+      - uses: reviewdog/action-setup@v1
+        with:
+          reviewdog_version: latest
       - name: Run reviewdog
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/json-iterator/go v1.1.7 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.3-0.20201104145324-b4fabd54ef88
+	github.com/keptn/go-utils v0.6.3-0.20201126154203-d12fe6bf7a06
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
-github.com/keptn/go-utils v0.6.3-0.20201104145324-b4fabd54ef88 h1:csTLzDPkYAvqz72d/Gw1FjBjWn6J/H7S41slMWPLqgE=
-github.com/keptn/go-utils v0.6.3-0.20201104145324-b4fabd54ef88/go.mod h1:jD+ZvrkwYyDMgeKANzVZsBSYgjYQxTJvxw/RB3vYFAE=
+github.com/keptn/go-utils v0.6.3-0.20201126154203-d12fe6bf7a06 h1:KGk2MGCsnCAhB5LLmMRy/7t7hiThaLqq7InNFf2ipBk=
+github.com/keptn/go-utils v0.6.3-0.20201126154203-d12fe6bf7a06/go.mod h1:jD+ZvrkwYyDMgeKANzVZsBSYgjYQxTJvxw/RB3vYFAE=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/lib/prometheus/prometheus.go
+++ b/lib/prometheus/prometheus.go
@@ -62,7 +62,7 @@ func NewPrometheusHandler(apiURL string, project string, stage string, service s
 }
 
 // GetSLIValue retrieves the specified value via the Prometheus API
-func (ph *Handler) GetSLIValue(metric string, start string, end string, logger *keptncommon.Logger) (float64, error) {
+func (ph *Handler) GetSLIValue(metric string, start string, end string, logger keptncommon.LoggerInterface) (float64, error) {
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
 	startUnix, err := parseUnixTimestamp(start)

--- a/lib/prometheus/prometheus.go
+++ b/lib/prometheus/prometheus.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
+	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"io/ioutil"
 	"math"
 	"net/http"
@@ -13,8 +14,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	keptn "github.com/keptn/go-utils/pkg/lib"
 )
 
 const Throughput = "throughput"
@@ -44,12 +43,12 @@ type Handler struct {
 	Stage         string
 	Service       string
 	HTTPClient    *http.Client
-	CustomFilters []*keptn.SLIFilter
+	CustomFilters []*keptnv2.SLIFilter
 	CustomQueries map[string]string
 }
 
 // NewPrometheusHandler returns a new prometheus handler that interacts with the Prometheus REST API
-func NewPrometheusHandler(apiURL string, project string, stage string, service string, customFilters []*keptn.SLIFilter) *Handler {
+func NewPrometheusHandler(apiURL string, project string, stage string, service string, customFilters []*keptnv2.SLIFilter) *Handler {
 	ph := &Handler{
 		ApiURL:        apiURL,
 		Project:       project,

--- a/lib/prometheus/prometheus_test.go
+++ b/lib/prometheus/prometheus_test.go
@@ -2,6 +2,7 @@ package prometheus
 
 import (
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
+	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 	"net"
@@ -11,8 +12,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	keptnevents "github.com/keptn/go-utils/pkg/lib"
 )
 
 func testingHTTPClient(handler http.Handler) (*http.Client, func()) {
@@ -45,9 +44,9 @@ func TestGetErrorRateQueryWithoutFilter(t *testing.T) {
 
 func TestGetErrorRateQueryWithFilter(t *testing.T) {
 
-	var customFilters []*keptnevents.SLIFilter
+	var customFilters []*keptnv2.SLIFilter
 
-	customFilters = append(customFilters, &keptnevents.SLIFilter{
+	customFilters = append(customFilters, &keptnv2.SLIFilter{
 		Key:   "handler",
 		Value: "=~'ItemsController'",
 	})
@@ -67,12 +66,12 @@ func TestGetErrorRateQueryWithFilter(t *testing.T) {
 
 func TestGetCustomErrorRateQueryWithFilter(t *testing.T) {
 
-	var customFilters []*keptnevents.SLIFilter
+	var customFilters []*keptnv2.SLIFilter
 
 	customQueries := map[string]string{}
 	customQueries["error_rate"] = "sum(rate(my_custom_metric{job='$SERVICE-$PROJECT-$STAGE',handler=~'$HANDLER',status!~'2..'}[$DURATION_SECONDS]))/sum(rate(my_custom_metric{job='$SERVICE-$PROJECT-$STAGE',handler=~'$HANDLER'}[$DURATION_SECONDS]))"
 
-	customFilters = append(customFilters, &keptnevents.SLIFilter{
+	customFilters = append(customFilters, &keptnv2.SLIFilter{
 		Key:   "handler",
 		Value: "'ItemsController'",
 	})
@@ -108,12 +107,12 @@ func TestGetThroughputQuery(t *testing.T) {
 
 func TestGetCustomThroughputQueryWithFilter(t *testing.T) {
 
-	var customFilters []*keptnevents.SLIFilter
+	var customFilters []*keptnv2.SLIFilter
 
 	customQueries := map[string]string{}
 	customQueries["throughput"] = "rate(my_custom_metric{job='$SERVICE-$PROJECT-$STAGE',handler=~'$HANDLER'}[$DURATION_SECONDS])"
 
-	customFilters = append(customFilters, &keptnevents.SLIFilter{
+	customFilters = append(customFilters, &keptnv2.SLIFilter{
 		Key:   "handler",
 		Value: "'ItemsController'",
 	})
@@ -148,12 +147,12 @@ func TestGetRequestLatencyQuery(t *testing.T) {
 
 func TestGetCustomResponseTimeQueryWithFilter(t *testing.T) {
 
-	var customFilters []*keptnevents.SLIFilter
+	var customFilters []*keptnv2.SLIFilter
 
 	customQueries := map[string]string{}
 	customQueries["response_time_p50"] = "histogram_quantile(0.50,sum(rate(my_custom_response_time_metric{job='$SERVICE-$PROJECT-$STAGE'}[$DURATION_SECONDS]))by(le))"
 
-	customFilters = append(customFilters, &keptnevents.SLIFilter{
+	customFilters = append(customFilters, &keptnv2.SLIFilter{
 		Key:   "handler",
 		Value: "'ItemsController'",
 	})
@@ -195,9 +194,9 @@ func TestGetCustomQuery(t *testing.T) {
 
 func TestGetDefaultFilterExpression(t *testing.T) {
 
-	var customFilters []*keptnevents.SLIFilter
+	var customFilters []*keptnv2.SLIFilter
 
-	customFilters = append(customFilters, &keptnevents.SLIFilter{
+	customFilters = append(customFilters, &keptnv2.SLIFilter{
 		Key:   "handler",
 		Value: "ItemsController",
 	})
@@ -215,9 +214,9 @@ func TestGetDefaultFilterExpression(t *testing.T) {
 
 func TestGetDefaultFilterExpressionWithOperand(t *testing.T) {
 
-	var customFilters []*keptnevents.SLIFilter
+	var customFilters []*keptnv2.SLIFilter
 
-	customFilters = append(customFilters, &keptnevents.SLIFilter{
+	customFilters = append(customFilters, &keptnv2.SLIFilter{
 		Key:   "handler",
 		Value: "!='ItemsController'",
 	})
@@ -235,9 +234,9 @@ func TestGetDefaultFilterExpressionWithOperand(t *testing.T) {
 
 func TestGetDefaultFilterExpressionWithJobName(t *testing.T) {
 
-	var customFilters []*keptnevents.SLIFilter
+	var customFilters []*keptnv2.SLIFilter
 
-	customFilters = append(customFilters, &keptnevents.SLIFilter{
+	customFilters = append(customFilters, &keptnv2.SLIFilter{
 		Key:   "job",
 		Value: "my-job",
 	})
@@ -255,9 +254,9 @@ func TestGetDefaultFilterExpressionWithJobName(t *testing.T) {
 
 func TestGetDefaultFilterExpressionWithSingleQuote(t *testing.T) {
 
-	var customFilters []*keptnevents.SLIFilter
+	var customFilters []*keptnv2.SLIFilter
 
-	customFilters = append(customFilters, &keptnevents.SLIFilter{
+	customFilters = append(customFilters, &keptnv2.SLIFilter{
 		Key:   "handler",
 		Value: "'ItemsController'",
 	})
@@ -275,9 +274,9 @@ func TestGetDefaultFilterExpressionWithSingleQuote(t *testing.T) {
 
 func TestGetDefaultFilterExpressionWithDoubleQuote(t *testing.T) {
 
-	var customFilters []*keptnevents.SLIFilter
+	var customFilters []*keptnv2.SLIFilter
 
-	customFilters = append(customFilters, &keptnevents.SLIFilter{
+	customFilters = append(customFilters, &keptnv2.SLIFilter{
 		Key:   "handler",
 		Value: "\"ItemsController\"",
 	})

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 const configservice = "CONFIGURATION_SERVICE"
 const eventbroker = "EVENTBROKER"
 const sliResourceURI = "prometheus/sli.yaml"
+const serviceName = "prometheus-sli-service"
 
 type envConfig struct {
 	// Port on which to listen for cloudevents
@@ -92,7 +93,7 @@ func processEvent(event cloudevents.Event) error {
 		return fmt.Errorf("could not determine keptnContext of input event: %s", err.Error())
 	}
 
-	log := keptncommon.NewLogger(keptnCtx, event.Context.GetID(), "prometheus-sli-service")
+	log := keptncommon.NewLogger(keptnCtx, event.Context.GetID(), serviceName)
 
 	// don't continue if SLIProvider is not prometheus
 	if eventData.GetSLI.SLIProvider != "prometheus" {
@@ -123,7 +124,7 @@ func retrieveMetrics(event cloudevents.Event, eventData *keptnv2.GetSLITriggered
 
 	clusterConfig, err := rest.InClusterConfig()
 	if err != nil {
-		log.Error("could not create Kubernetes client")
+		log.Error("could not create Kubernetes cluster config")
 		return nil, errors.New("could not create Kubernetes client")
 	}
 
@@ -261,7 +262,7 @@ func generatePrometheusURL(pc *prometheusCredentials) string {
 
 func sendGetSLIStartedEvent(inputEvent cloudevents.Event, eventData *keptnv2.GetSLITriggeredEventData, keptnContext interface{}) error {
 
-	source, _ := url.Parse("prometheus-sli-service")
+	source, _ := url.Parse(serviceName)
 
 	getSLIStartedEvent := keptnv2.GetSLIStartedEventData{
 		EventData: keptnv2.EventData{
@@ -286,8 +287,7 @@ func sendGetSLIStartedEvent(inputEvent cloudevents.Event, eventData *keptnv2.Get
 }
 
 func sendGetSLIFinishedEvent(inputEvent cloudevents.Event, eventData *keptnv2.GetSLITriggeredEventData, indicatorValues []*keptnv2.SLIResult, err error, keptnContext interface{}) error {
-	source, _ := url.Parse("prometheus-sli-service")
-
+	source, _ := url.Parse(serviceName)
 	var status = keptnv2.StatusSucceeded
 	var result = keptnv2.ResultPass
 	var message = ""

--- a/main.go
+++ b/main.go
@@ -68,17 +68,17 @@ func _main(args []string, env envConfig) int {
 	return 0
 }
 
-func gotEvent(ctx context.Context, event cloudevents.Event) error {
+func gotEvent(event cloudevents.Event) error {
 
 	switch event.Type() {
 	case keptnv2.GetTriggeredEventType(keptnv2.GetSLITaskName):
-		return retrieveMetrics(event) // backwards compatibility to Keptn versions <= 0.5.x
+		return processEvent(event) // backwards compatibility to Keptn versions <= 0.5.x
 	default:
 		return errors.New("received unknown event type")
 	}
 }
 
-func retrieveMetrics(event cloudevents.Event) error {
+func processEvent(event cloudevents.Event) error {
 	var shkeptncontext string
 	event.Context.ExtensionAs("shkeptncontext", &shkeptncontext)
 

--- a/main.go
+++ b/main.go
@@ -343,7 +343,5 @@ func sendEvent(event cloudevents.Event) error {
 		return err
 	}
 
-	_ = keptnHandler.SendCloudEvent(event)
-
-	return nil
+	return keptnHandler.SendCloudEvent(event)
 }


### PR DESCRIPTION
closes #44 

The code was mainly just rearranged to support sending `.started` and `.finished` events.
Large parts of the business logic remain untested which shall be tackled in a follow-up issue: (#47 )

