### PR TITLE
Use keptn/gh-action-extract-branch-name

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,34 +44,9 @@ jobs:
 
       - name: Extract branch name
         id: extract_branch
-        shell: bash
-        run: |
-          if [[ "${GITHUB_REF}" == "refs/heads"* ]]; then
-            echo "This is a push to a local branch -> using branch name"
-            BRANCH=${GITHUB_REF#refs/heads/}
-            BRANCH_SLUG=$(echo $BRANCH | iconv -t ascii//TRANSLIT | sed -r s/[^a-zA-Z0-9]+/-/g | sed -r s/^-+\|-+$//g | tr A-Z a-z)
-          else
-            if [[ "${GITHUB_REF}" == "refs/pull/"* ]]; then
-              # usually the format for PRs is: refs/pull/1234/merge
-              echo "This is a Pull Request -> using PR ID"
-              tmp=${GITHUB_REF#refs/pull/}
-              # remove the last "/merge"
-              # Branch name is basically the PR id
-              BRANCH=${tmp%/merge}
-              # And Slug is "PR-${PRID}"
-              BRANCH_SLUG=PR-${BRANCH}
-            else
-              echo "::error This is neither a push, nor a PR, probably something else... Exiting"
-              exit 1
-            fi
-          fi
+        # see https://github.com/keptn/gh-action-extract-branch-name for details
+        uses: keptn/gh-action-extract-branch-name@main
 
-          GIT_SHA="$(git rev-parse --short HEAD)"
-
-          # print GIT_SHA, BRANCH and BRANCH_SLUG (make sure they are also set in needs.prepare_ci_run.outputs !!!)
-          echo "##[set-output name=BRANCH;]$(echo ${BRANCH})"
-          echo "##[set-output name=BRANCH_SLUG;]$(echo ${BRANCH_SLUG})"
-          echo "##[set-output name=GIT_SHA;]$(echo ${GIT_SHA})"
       - name: 'Get Previous tag'
         id: get_previous_tag
         uses: "WyriHaximus/github-action-get-previous-tag@1.0.0"


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

Based on https://github.com/keptn/keptn/issues/2824 this PR introduces a new GH action for extracting the branch name, therefore reducing the CI workflows complexity within this repository.